### PR TITLE
added content describing app features  to about page

### DIFF
--- a/src/components/AboutPage/AboutPage.jsx
+++ b/src/components/AboutPage/AboutPage.jsx
@@ -8,10 +8,41 @@ import React from 'react';
 function AboutPage() {
   return (
     <div className="container">
-      <div>
-        <p>This about page is for anyone to read!</p>
+        <h1 style={{color: 'purple'}}>About My Assistant</h1>
+        <p>My Assistant is a user-friendly event management application designed to 
+          simplify the planning, organization, and viewing of events. It fosters a 
+          sense of community by helping users connect through events while providing 
+          tools to enhance organization and accessibility.
+        </p>
+
+        <h2 style={{color: 'purple'}}>Key Features</h2>
+          <ul>
+            <li>
+              <span style={{ fontWeight: 'bold', color: 'purple' }}>Event Scheduling:</span> Any user can create events and decide whether they are 
+              public or private.
+            </li>
+            <li>
+              <span style={{ fontWeight: 'bold', color: 'purple' }}>Effortless Event Viewing:</span> Public events are viewable by all users, while 
+              private events are accessible only to invited participants.
+            </li>
+            <li>
+              <span style={{ fontWeight: 'bold', color: 'purple' }}>Event Notes and Tasks:</span> Add notes and tasks specific to each event, helping 
+              users stay organized and track important details.
+            </li>
+            <li>
+              <span style={{ fontWeight: 'bold', color: 'purple' }}>Search by Events or User Skills:</span> Find events easily or search for users based 
+              on their listed skills to connect with the right contributors and participants.
+            </li>
+            <li>
+              <span style={{ fontWeight: 'bold', color: 'purple' }}>Privacy Controls:</span> Ensure that private event details remain secure and visible 
+              only to the intended audience.
+            </li>
+          </ul>
+
+        <h2 style={{color: 'purple'}}>Purpose</h2>
+        <p>The app is designed not only to simplify event planning but also to strengthen connections within a community. Whether creating public gatherings or private events, My Assistant helps users share their skills, organize effectively, and engage with others. Its practical features and collaborative design empower users to build meaningful relationships while managing events with ease.
+        </p>
       </div>
-    </div>
   );
 }
 


### PR DESCRIPTION
Added content to About My Assistant  page describing app features. Used inline styles directly in elements (headlines 1 & 2 and lists) for bold font with purple color - since did this with inline styles hope it doesn't apply globally. Need help as when tested, the copy appears but it is horizontal, or side by side rather than  one section above another section. Wondering if this has anything to do with other styling in the app, although the About page was independent in template.